### PR TITLE
Added Read, List Promotions functionality with text cases

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -15,7 +15,7 @@
 ######################################################################
 
 """
-Pet Store Service
+Product Promotion Service
 
 This service implements a REST API that allows you to Create, Read, Update
 and Delete Promotions from the inventory of promotions
@@ -45,7 +45,7 @@ def index():
 
 
 ######################################################################
-# CREATE A NEW PET
+# CREATE A NEW PROMOTION
 ######################################################################
 @app.route("/promotions", methods=["POST"])
 def create_promotions():
@@ -68,7 +68,50 @@ def create_promotions():
     app.logger.info("Promotions with ID: %d created.", promotions.promo_id)
     return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
 
-    ######################################################################
+
+######################################################################
+# LIST ALL PROMOTIONS
+######################################################################
+@app.route("/promotions", methods=["GET"])
+def list_promotions():
+    """Returns all of the Promotions"""
+    app.logger.info("Request for promotion list")
+
+    promotions = []
+
+    # See if any query filters were passed in
+    category = request.args.get("category")
+    name = request.args.get("name")
+    if category:
+        promotions = Promotions.find_by_category(category)
+    elif name:
+        promotions = Promotions.find_by_name(name)
+    else:
+        promotions = Promotions.all()
+
+    results = [promotion.serialize() for promotion in promotions]
+    app.logger.info("Returning %d promotions", len(results))
+    return jsonify(results), status.HTTP_200_OK
+
+
+######################################################################
+# READ A PROMOTION
+######################################################################
+@app.route("/promotions/<int:promotion_id>", methods=["GET"])
+def get_product(promotion_id):
+    """
+    Retrieve a single Promotion
+
+    This endpoint will return a Promotion based on it's id
+    """
+    app.logger.info("Request for pet with id: %s", promotion_id)
+
+    promotion = Promotions.find(promotion_id)
+    if not promotion:
+        error(status.HTTP_404_NOT_FOUND, f"Pet with id '{promotion_id}' was not found.")
+
+    app.logger.info("Returning promotion: %s", promotion.promo_id)
+    return jsonify(promotion.serialize()), status.HTTP_200_OK
 
 
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -10,7 +10,7 @@ from service.models import Promotions, Type
 
 
 class PromotionsFactory(factory.Factory):
-    """Creates fake pets that you don't have to feed"""
+    """Creates fake promotions that you don't have to feed"""
 
     class Meta:  # pylint: disable=too-few-public-methods
         """Maps factory to data model"""


### PR DESCRIPTION
## Implementation
1. Implemented Read Promotions
2. Implemented List All Promotions
3. written tests for read promotion
4. written tests for list promotion
5. Fixed _create_promotions in terms of PromotionFactory [id error]

## Requests
List All Promotion CuRL req
`curl 'http://localhost:8000/promotions' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Sec-Fetch-Dest: document' \
  -H 'Sec-Fetch-Mode: navigate' \
  -H 'Sec-Fetch-Site: none' \
  -H 'Sec-Fetch-User: ?1' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'User-Agent: Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36' \
  -H 'sec-ch-ua: "Chromium";v="122", "Not(A:Brand";v="24", "Google Chrome";v="122"' \
  -H 'sec-ch-ua-mobile: ?1' \
  -H 'sec-ch-ua-platform: "Android"'`
  
  Read Promotion CuRL req
`curl 'http://localhost:8000/promotions/1' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Sec-Fetch-Dest: document' \
  -H 'Sec-Fetch-Mode: navigate' \
  -H 'Sec-Fetch-Site: none' \
  -H 'Sec-Fetch-User: ?1' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'User-Agent: Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36' \
  -H 'sec-ch-ua: "Chromium";v="122", "Not(A:Brand";v="24", "Google Chrome";v="122"' \
  -H 'sec-ch-ua-mobile: ?1' \
  -H 'sec-ch-ua-platform: "Android"'`


## Output
#### GET /promotions
<img src="https://github.com/CSCI-GA-2820-SP24-001/promotions/assets/106952318/f3d98543-2b0a-49eb-b1e3-1c55d523203e" width="500">

#### GET /promotions/<promotion_id>
<img src="https://github.com/CSCI-GA-2820-SP24-001/promotions/assets/106952318/bcc2f857-c289-4b3c-9993-42076d6483d6" width="500">
